### PR TITLE
(RE-941) Enable workload identity and update GSA perms

### DIFF
--- a/gke/private_kubernetes/extra-vms.tf
+++ b/gke/private_kubernetes/extra-vms.tf
@@ -19,6 +19,12 @@ resource "google_project_iam_member" "k8s_bastion_compute_admin" {
   member     = "serviceAccount:${google_service_account.k8s_bastion_service_account.email}"
 }
 
+resource "google_project_iam_member" "k8s_bastion_dns_admin" {
+  count      = var.privileged_bastion ? 1 : 0
+  depends_on = [google_service_account.k8s_bastion_service_account]
+  role       = "roles/dns.admin"
+  member     = "serviceAccount:${google_service_account.k8s_bastion_service_account.email}"
+}
 
 resource "google_compute_instance" "bastion" {
   count                     = var.enable_bastion ? 1 : 0

--- a/gke/private_kubernetes/main.tf
+++ b/gke/private_kubernetes/main.tf
@@ -126,8 +126,10 @@ resource "google_container_node_pool" "node_pool" {
 
     tags   = local.all_node_tags
     labels = local.all_labels
+    workload_metadata_config {
+      node_metadata = "GKE_METADATA_SERVER"
+    }
   }
-
   management {
     auto_repair  = var.node_auto_repair
     auto_upgrade = var.node_auto_upgrade
@@ -198,5 +200,8 @@ resource "google_container_cluster" "circleci_cluster" {
   # field as this is almost never the desired outcome.
   lifecycle {
     ignore_changes = [description, ]
+  }
+  workload_identity_config {
+    identity_namespace = "${var.project_id}.svc.id.goog"
   }
 }


### PR DESCRIPTION
The google service account needs DNS Admin permissions to be able to bind with the `external-dns` service.