### PR TITLE
Enable GKE release selection and update timeouts for create/update/delete

### DIFF
--- a/gke/main.tf
+++ b/gke/main.tf
@@ -28,6 +28,8 @@ module "kube_private_cluster" {
   }
   node_tags = []
 
+  gke_release_channel = var.gke_release_channel
+
   # Node pool configuration
   preemptible_nodes  = var.preemptible_k8s_nodes
   nodes_machine_spec = var.node_spec

--- a/gke/output.tf
+++ b/gke/output.tf
@@ -11,7 +11,7 @@ output "nomad_server_cert" {
 }
 
 output "nomad_server_key" {
-  value = nonsensitive(module.nomad.nomad_server_key)
+  value = module.nomad.nomad_server_key
 }
 
 output "nomad_tls_ca" {

--- a/gke/private_kubernetes/main.tf
+++ b/gke/private_kubernetes/main.tf
@@ -137,7 +137,7 @@ resource "google_container_node_pool" "node_pool" {
 
   timeouts {
     create = "90m"
-    update = "120m"
+    update = "90m"
     delete = "60m"
   }
 

--- a/gke/private_kubernetes/main.tf
+++ b/gke/private_kubernetes/main.tf
@@ -109,7 +109,7 @@ resource "google_container_node_pool" "node_pool" {
   location = var.location
   cluster  = google_container_cluster.circleci_cluster.name
 
-  version = data.google_container_engine_versions.gke.release_channel_default_version["REGULAR"]
+  version = data.google_container_engine_versions.gke.release_channel_default_version[var.gke_release_channel]
 
   autoscaling {
     min_node_count = var.node_min
@@ -134,6 +134,13 @@ resource "google_container_node_pool" "node_pool" {
     auto_repair  = var.node_auto_repair
     auto_upgrade = var.node_auto_upgrade
   }
+
+  timeouts {
+    create = "90m"
+    update = "120m"
+    delete = "60m"
+  }
+
 }
 
 
@@ -148,7 +155,7 @@ resource "google_container_cluster" "circleci_cluster" {
   location    = var.location
   provider    = google-beta
 
-  min_master_version = data.google_container_engine_versions.gke.release_channel_default_version["REGULAR"]
+  min_master_version = data.google_container_engine_versions.gke.release_channel_default_version[var.gke_release_channel]
 
   network = var.network_uri
   # subnetwork               = var.subnet_uri

--- a/gke/private_kubernetes/variables.tf
+++ b/gke/private_kubernetes/variables.tf
@@ -141,3 +141,9 @@ variable "preemptible_nodes" {
   default     = false
   description = "Use preemptible nodes for cluster. Keeps cost low for development or proof of concept cluster"
 }
+
+variable "gke_release_channel" {
+  type = string
+  default = "REGULAR"
+  description = "The GKE release channel to subscribe to. Should be one of RAPID/REGULAR/STABLE"
+}

--- a/gke/terraform.tfvars.template
+++ b/gke/terraform.tfvars.template
@@ -4,6 +4,8 @@ project_loc       = ""        # Region to create cluster IE us-east1
 
 force_destroy     = false     # Forces destroy of the S3 data bucket on `terraform destroy`.  Useful as true for development purposes.  Data in bucket will be unrecoverable   
 
+gke_release_channel = "REGULAR"
+
 node_spec         = "n1-standard-8"
 node_min          = 1
 node_max          = 9

--- a/gke/variables.tf
+++ b/gke/variables.tf
@@ -19,6 +19,12 @@ variable "basename" {
   description = "Name of deployment to be used as a base for naming resources."
 }
 
+variable "gke_release_channel" {
+  type = string
+  default = "REGULAR"
+  description = "The GKE release channel to subscribe to. Should be one of RAPID/REGULAR/STABLE"
+}
+
 variable "node_spec" {
   type        = string
   default     = "n1-standard-8"


### PR DESCRIPTION
:gear: **Issue**

RE 1285 - https://circleci.atlassian.net/browse/RE-1285

:white_check_mark: **Fix**

Added the following -
- Option to select GKE release channel (that would enable selection of a particular k8s version)
- Updated the default timeouts for create/update/delete, since all resources usually take more than the default timeout of 30 mins
- Removed `nonsensitive` from output nomad_server_key, since it is not sensitive and causes a redundant error.
```
Error: Invalid function argument
│
│   on output.tf line 14, in output "nomad_server_key":
│   14:   value = nonsensitive(module.nomad.nomad_server_key)
│     ├────────────────
│     │ module.nomad.nomad_server_key is ""
│
│ Invalid value for "value" parameter: the given value is not sensitive, so this call is redundant.
```

:question: **Tests**

Deployed an environment with the changes

- [ ] Passed _reality check_
